### PR TITLE
Release Version 1.0.0 on Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Artemis Java Test Sandbox
-![Java CI](https://github.com/MaisiKoleni/artemis-java-test-sandbox/workflows/Java%20CI/badge.svg?branch=master)
+![Java CI](https://github.com/ls1intum/artemis-java-test-sandbox/workflows/Java%20CI/badge.svg?branch=master)
 
 Artemis Java Test Sandbox *(abbr. AJTS)* is a JUnit 5 extension for easy and secure Java testing
 on the interactive learning platform [Artemis](https://github.com/ls1intum/Artemis).
@@ -16,29 +16,19 @@ Its main features are
 
 *Note: AJTS requires at least Java 11.*
 
-AJTS is provided as Maven dependency. To use AJTS in the test environment of a Maven project, use
+AJTS is provided as Maven dependency. To use AJTS in the test environment of a Maven project, include
 
 ```xml
 <dependency>
     <groupId>de.tum.in</groupId>
     <artifactId>artemis-java-test-sandbox</artifactId>
-    <version>0.5.1</version>
+    <version>1.0.0</version>
     <scope>test</scope>
 </dependency>
 ```
 
-in the `dependencies` section and include the following block in your `pom.xml` to tell
-Maven where to find the AJTS resources:
+in the `dependencies` section.
 
-```xml
-<repositories>
-    <repository>
-        <id>ajts</id>
-        <name>AJTS Maven Packages</name>
-        <url>https://gitlab.com/ajts-mvn/repo/raw/master/</url>
-    </repository>
-</repositories>
-```
 You can now remove dependencies to JUnit 5, AssertJ and Hamcrest if present because AJTS already includes them.
 If you want to use jqwik or JUnit 4 (JUnit 5 vintage), simply include them in the dependencies section.
 
@@ -73,19 +63,11 @@ Assume you have a Java 11 Maven project, and the inside of `pom.xml` looks like 
     <maven.compiler.target>11</maven.compiler.target>
 </properties>
 
-<repositories>
-    <repository>
-        <id>ajts</id>
-        <name>AJTS Maven Packages</name>
-        <url>https://gitlab.com/ajts-mvn/repo/raw/master/</url>
-    </repository>
-</repositories>
-
 <dependencies>
     <dependency>
         <groupId>de.tum.in</groupId>
         <artifactId>artemis-java-test-sandbox</artifactId>
-        <version>0.5.1</version>
+        <version>1.0.0</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
@@ -263,7 +245,7 @@ Add a `@BlacklistPath` for other important classes, like your reference implemen
 
 *Note: the Artemis project starts with `course1920xyz`, but the build in Bamboo (by Artemis) will
 happen in a directory named after the build plan, which is in upper case and therefore,
-begins with `COURSE1920XYZ`. Make sure that you do not build multiple student solutions 
+begins with `COURSE1920XYZ`. Make sure that you do not build multiple student solutions
 in the same directory on the same machine using the git clone (lower case) approach. Otherwise, adjust the whitelisting to your needs.*
 
 As a side note: should you require that test classes written by students are themselves tested, call your classes `...TestTest` and then use `@BlacklistPath(value = "**TestTest*.{java,class}", type = PathType.GLOB)`.
@@ -333,6 +315,21 @@ In progress, see also `@AllowLocalPort`.
 
 ## Additional Notes
 
+#### Older Versions
+
+For versions prior to `1.0.0`, this repository block had to be added to the `pom.xml`:
+```xml
+<repositories>
+    <repository>
+        <id>ajts</id>
+        <name>AJTS Maven Packages</name>
+        <url>https://gitlab.com/ajts-mvn/repo/raw/master/</url>
+    </repository>
+</repositories>
+```
+**Using older AJTS versions is highly discouraged, remove these repository declarations and update to the newest AJTS version
+if they appear in your projects.**
+
 #### GitHub Packages
 
 GitHub Packages does currently not allow unregistered, public access to the
@@ -349,4 +346,4 @@ packages. Therefore, you will need to authenticate to GitHub if you use
 
 ## License
 
-AJTS was created by Christian Femers and is licensed under the [MIT License, see `LICENSE.md`](https://github.com/MaisiKoleni/artemis-java-test-sandbox/blob/master/LICENSE).
+AJTS was created by Christian Femers and is licensed under the [MIT License, see `LICENSE.md`](https://github.com/ls1intum/artemis-java-test-sandbox/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.tum.in.ase</groupId>
 	<artifactId>artemis-java-test-sandbox</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.0</version>
 	<name>Artemis Java Test Sandbox</name>
 	<description>JUnit 5 Extension API for secure Artemis Java Testing</description>
 	<url>https://github.com/ls1intum/artemis-java-test-sandbox</url>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>de.tum.in</groupId>
+	<groupId>de.tum.in.ase</groupId>
 	<artifactId>artemis-java-test-sandbox</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<name>Artemis Java Test Sandbox</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.tum.in</groupId>
 	<artifactId>artemis-java-test-sandbox</artifactId>
-	<version>0.5.3-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<name>Artemis Java Test Sandbox</name>
 	<description>JUnit 5 Extension API for secure Artemis Java Testing</description>
 	<url>https://github.com/MaisiKoleni/artemis-java-test-sandbox</url>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
 		<jqwik-version>1.2.7</jqwik-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<!-- full certificate fingerprint: B58E410970742EF7AD0FDD48D1A045E1DD48B876 -->
+		<gpg.key.id>D1A045E1DD48B876</gpg.key.id>
 	</properties>
 
 	<dependencies>
@@ -137,7 +139,7 @@
 					<execution>
 						<phase>package</phase>
 						<goals>
-							<goal>jar</goal>
+							<goal>jar-no-fork</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -180,6 +182,16 @@
 					</rules>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.7</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -209,6 +221,49 @@
 					<url>file://${project.build.directory}/mvn-repo</url>
 				</repository>
 			</distributionManagement>
+		</profile>
+		<!-- Profile for manually deploying to Maven Central -->
+		<profile>
+			<id>ossrh</id>
+			<distributionManagement>
+				<snapshotRepository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</snapshotRepository>
+				<repository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
+			<build>
+				<plugins>
+					<!-- Only sign the plugin if it's built manually for OSSRH -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<keyname>${gpg.key.id}</keyname>
+									<passphraseServerId>${gpg.key.id}</passphraseServerId>
+									<!-- This is to prevent Maven GPG not passing the passphrase correctly
+										requires GPG version 2.1 or greater -->
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<name>Artemis Java Test Sandbox</name>
 	<description>JUnit 5 Extension API for secure Artemis Java Testing</description>
-	<url>https://github.com/MaisiKoleni/artemis-java-test-sandbox</url>
+	<url>https://github.com/ls1intum/artemis-java-test-sandbox</url>
 	<inceptionYear>2019</inceptionYear>
 	<licenses>
 		<license>
 			<name>MIT</name>
 			<url>https://opensource.org/licenses/MIT</url>
-			<comments>See https://github.com/MaisiKoleni/artemis-java-test-sandbox/blob/master/LICENSE</comments>
+			<comments>See https://github.com/ls1intum/artemis-java-test-sandbox/blob/master/LICENSE</comments>
 		</license>
 	</licenses>
 	<developers>
@@ -26,9 +26,9 @@
 	</developers>
 
 	<scm>
-		<url>https://github.com/MaisiKoleni/artemis-java-test-sandbox</url>
-		<connection>scm:git:https://github.com/MaisiKoleni/artemis-java-test-sandbox.git</connection>
-		<developerConnection>scm:git:https://github.com/MaisiKoleni/artemis-java-test-sandbox.git</developerConnection>
+		<url>https://github.com/ls1intum/artemis-java-test-sandbox</url>
+		<connection>scm:git:https://github.com/ls1intum/artemis-java-test-sandbox.git</connection>
+		<developerConnection>scm:git:https://github.com/ls1intum/artemis-java-test-sandbox.git</developerConnection>
 	</scm>
 
 	<properties>
@@ -191,7 +191,7 @@
 				<repository>
 					<id>github</id>
 					<name>GitHub MaisiKoleni Apache Maven Packages</name>
-					<url>https://maven.pkg.github.com/MaisiKoleni/artemis-java-test-sandbox</url>
+					<url>https://maven.pkg.github.com/ls1intum/artemis-java-test-sandbox</url>
 				</repository>
 				<!-- GitHub cannot handle snapshots correctly now, so we do nothing -->
 				<snapshotRepository>


### PR DESCRIPTION
Release AJTS Version as 1.0.0 to Maven Central with the group id `de.tum.in.ase`. This resolves #26.

- [x] Move GitHub repository to @ls1intum 
- [x] Change group id in the `pom.xml`
- [x] Update all references to the @MaisiKoleni repository
- [x] Update `pom.xml` to deploy snapshots to https://oss.sonatype.org/content/repositories/snapshots
- [x] Update `pom.xml` to deploy releases to https://oss.sonatype.org/service/local/staging/deploy/maven2
- [x] Sign the deployed artifacts using PGP, find a good process to do so.
- [x] Update `README.md`, remove the explicit `<repositories>`