### PR TITLE
Update to JUnit 5 Version 5.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
-		<junit-jupiter-version>5.7.0-RC1</junit-jupiter-version>
-		<junit-platform-version>1.7.0-RC1</junit-platform-version>
+		<junit-jupiter-version>5.7.0</junit-jupiter-version>
+		<junit-platform-version>1.7.0</junit-platform-version>
 		<jqwik-version>1.3.4</jqwik-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
-		<junit-jupiter-version>5.6.2</junit-jupiter-version>
-		<junit-platform-version>1.6.2</junit-platform-version>
+		<junit-jupiter-version>5.7.0-RC1</junit-jupiter-version>
+		<junit-platform-version>1.7.0-RC1</junit-platform-version>
 		<jqwik-version>1.3.4</jqwik-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/test/java/de/tum/in/testuser/DeadlineUser.java
+++ b/src/test/java/de/tum/in/testuser/DeadlineUser.java
@@ -1,6 +1,6 @@
 package de.tum.in.testuser;
 
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.Deadline;
@@ -8,7 +8,7 @@ import de.tum.in.test.api.jupiter.HiddenTest;
 import de.tum.in.test.api.jupiter.PublicTest;
 
 @Deadline("2200-01-01 16:00")
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 public class DeadlineUser {
 
 	@HiddenTest

--- a/src/test/java/de/tum/in/testuser/ExceptionFailureUser.java
+++ b/src/test/java/de/tum/in/testuser/ExceptionFailureUser.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import org.assertj.core.api.SoftAssertionError;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.MultipleAssertionsError;
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.AllowThreads;
@@ -21,7 +21,7 @@ import de.tum.in.test.api.jupiter.PublicTest;
 import de.tum.in.testuser.subject.CustomException;
 
 @AllowThreads(maxActiveCount = 100)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 //@UseLocale("en")
 @WhitelistPath(value = "target/**", type = PathType.GLOB)
 @BlacklistPath(value = "**Test.{java,class}", type = PathType.GLOB)

--- a/src/test/java/de/tum/in/testuser/HiddenPublicUser.java
+++ b/src/test/java/de/tum/in/testuser/HiddenPublicUser.java
@@ -1,6 +1,6 @@
 package de.tum.in.testuser;
 
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -9,7 +9,7 @@ import de.tum.in.test.api.jupiter.Hidden;
 import de.tum.in.test.api.jupiter.Public;
 
 @Deadline("2200-01-01 16:00")
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 public class HiddenPublicUser {
 
 	@Hidden

--- a/src/test/java/de/tum/in/testuser/InputOutputUser.java
+++ b/src/test/java/de/tum/in/testuser/InputOutputUser.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.BlacklistPath;
@@ -22,7 +22,7 @@ import de.tum.in.testuser.subject.InputOutputPenguin;
 
 @MirrorOutput(MirrorOutputPolicy.DISABLED)
 @StrictTimeout(value = 300, unit = TimeUnit.MILLISECONDS)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 @WhitelistPath(value = "target/**", type = PathType.GLOB)
 @BlacklistPath(value = "**Test*.{java,class}", type = PathType.GLOB)
 @SuppressWarnings("static-method")

--- a/src/test/java/de/tum/in/testuser/PackageAccessUser.java
+++ b/src/test/java/de/tum/in/testuser/PackageAccessUser.java
@@ -2,7 +2,7 @@ package de.tum.in.testuser;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.BlacklistPackage;
@@ -19,7 +19,7 @@ import de.tum.in.testuser.subject.PackageAccessPenguin;
 
 @MirrorOutput(MirrorOutputPolicy.DISABLED)
 @StrictTimeout(value = 300, unit = TimeUnit.MILLISECONDS)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 @UseLocale("en")
 @WhitelistPath(value = "target/**", type = PathType.GLOB)
 @BlacklistPath(value = "**Test*.{java,class}", type = PathType.GLOB)

--- a/src/test/java/de/tum/in/testuser/PathAccessUser.java
+++ b/src/test/java/de/tum/in/testuser/PathAccessUser.java
@@ -7,7 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.BlacklistPath;
@@ -21,7 +21,7 @@ import de.tum.in.testuser.subject.PathAccessPenguin;
 
 @MirrorOutput(MirrorOutputPolicy.DISABLED)
 @StrictTimeout(value = 300, unit = TimeUnit.MILLISECONDS)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 @WhitelistPath(value = "target/**", type = PathType.GLOB)
 @BlacklistPath(value = "**Test*.{java,class}", type = PathType.GLOB)
 @SuppressWarnings("static-method")

--- a/src/test/java/de/tum/in/testuser/PrivilegedExceptionUser.java
+++ b/src/test/java/de/tum/in/testuser/PrivilegedExceptionUser.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.BlacklistPath;
@@ -21,7 +21,7 @@ import de.tum.in.testuser.subject.PrivilegedExceptionPenguin;
 @PrivilegedExceptionsOnly("ABC")
 @MirrorOutput(MirrorOutputPolicy.DISABLED)
 @StrictTimeout(value = 300, unit = TimeUnit.MILLISECONDS)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 @WhitelistPath(value = "target/**", type = PathType.GLOB)
 @BlacklistPath(value = "**Test*.{java,class}", type = PathType.GLOB)
 @SuppressWarnings("static-method")

--- a/src/test/java/de/tum/in/testuser/SecurityUser.java
+++ b/src/test/java/de/tum/in/testuser/SecurityUser.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.xyz.Circumvention;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.AllowThreads;
@@ -23,7 +23,7 @@ import de.tum.in.testuser.subject.SecurityPenguin;
 @MirrorOutput(MirrorOutputPolicy.DISABLED)
 @AllowThreads(maxActiveCount = 100)
 @StrictTimeout(value = 300, unit = TimeUnit.MILLISECONDS)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 @UseLocale("en")
 @WhitelistPath(value = "target/**", type = PathType.GLOB)
 @BlacklistPath(value = "**Test*.{java,class}", type = PathType.GLOB)

--- a/src/test/java/de/tum/in/testuser/StrictTimeoutUser.java
+++ b/src/test/java/de/tum/in/testuser/StrictTimeoutUser.java
@@ -2,14 +2,14 @@ package de.tum.in.testuser;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.StrictTimeout;
 
 @StrictTimeout(value = 100, unit = TimeUnit.MILLISECONDS)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 @SuppressWarnings({ "static-method", "unused" })
 public class StrictTimeoutUser {
 

--- a/src/test/java/de/tum/in/testuser/ThreadUser.java
+++ b/src/test/java/de/tum/in/testuser/ThreadUser.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import de.tum.in.test.api.AllowThreads;
@@ -29,7 +29,7 @@ import de.tum.in.testuser.subject.ThreadPenguin;
 @AllowThreads(maxActiveCount = 100)
 @MirrorOutput(MirrorOutputPolicy.DISABLED)
 @StrictTimeout(value = 300, unit = TimeUnit.MILLISECONDS)
-@TestMethodOrder(Alphanumeric.class)
+@TestMethodOrder(MethodName.class)
 @WhitelistPath(value = "target/**", type = PathType.GLOB)
 @BlacklistPath(value = "**Test*.{java,class}", type = PathType.GLOB)
 @SuppressWarnings("static-method")


### PR DESCRIPTION
JUnit 5 Version 5.7.0 will be released on the 13. September 2020.

A lot has changed and was added, we have to change some things and might need / should add support for the new JUnit 5 features.

- [x] Check code for deprecation and fix it.
- [x] Fix broken tests (`@UseLocale` seems to be problematic?)
- [ ] Remove explicit dependency to params and other promoted features.
- [x] Switch from the RC1 Version to the GA Release.

See https://junit.org/junit5/docs/5.7.0-RC1/release-notes/.