### PR TITLE
Simple and canonical name support for Structure Test Oracle files

### DIFF
--- a/src/main/java/de/tum/in/test/api/structural/AttributeTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/AttributeTestProvider.java
@@ -218,8 +218,8 @@ public abstract class AttributeTestProvider extends StructuralTestProvider {
 			boolean genericTypeIsRight = false;
 
 			String expectedMainTypeName = expectedTypeName.split("<")[0];
-			String observedMainTypeName = observedAttribute.getType().getSimpleName();
-			mainTypeIsRight = expectedMainTypeName.equals(observedMainTypeName);
+			String observedMainTypeName = observedAttribute.getType().getCanonicalName();
+			mainTypeIsRight = checkExpectedName(observedMainTypeName, expectedMainTypeName);
 
 			if (observedAttribute.getGenericType() instanceof ParameterizedType) {
 				Type observedGenericType = observedAttribute.getGenericType();
@@ -231,7 +231,8 @@ public abstract class AttributeTestProvider extends StructuralTestProvider {
 
 			return mainTypeIsRight && genericTypeIsRight;
 		}
-		String observedTypeName = observedAttribute.getType().getSimpleName();
-		return expectedTypeName.equals(observedTypeName);
+		String observedTypeName = observedAttribute.getType().getCanonicalName();
+
+		return checkExpectedName(observedTypeName, expectedTypeName);
 	}
 }

--- a/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
@@ -123,16 +123,12 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 		// Filter out the enums, since there is a separate test for them
 		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
 				&& !expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS).equals("Enum")) {
-			String actualSuperClassName;
 			String expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
-			if (expectedSuperClassName.contains(".")) {
-				actualSuperClassName = observedClass.getSuperclass().getCanonicalName();
-			} else {
-				actualSuperClassName = observedClass.getSuperclass().getSimpleName();
-			}
-			String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
-					+ expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
-			if (!expectedSuperClassName.equals(actualSuperClassName)) {
+			String observedSuperClassName = observedClass.getSuperclass().getCanonicalName();
+
+			if (!checkExpectedName(observedSuperClassName, expectedSuperClassName)) {
+				String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
+						+ expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
 				fail(failMessage);
 			}
 		}
@@ -145,11 +141,9 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 			Class<?>[] observedInterfaces = observedClass.getInterfaces();
 			for (int i = 0; i < expectedInterfaces.length(); i++) {
 				String expectedInterface = expectedInterfaces.getString(i);
-				boolean hasSpecificPackage = expectedInterface.contains(".");
 				boolean implementsInterface = false;
 				for (Class<?> observedInterface : observedInterfaces) {
-					if ((hasSpecificPackage && expectedInterface.equals(observedInterface.getCanonicalName()))
-							|| expectedInterface.equals(observedInterface.getSimpleName())) {
+					if (checkExpectedName(observedInterface.getCanonicalName(), expectedInterface)) {
 						implementsInterface = true;
 						break;
 					}

--- a/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
@@ -27,150 +27,150 @@ import org.junit.jupiter.api.DynamicNode;
  */
 public abstract class ClassTestProvider extends StructuralTestProvider {
 
-    /**
-     * This method collects the classes in the structure oracle file for which at
-     * least one class property is specified. These classes are then transformed
-     * into JUnit 5 dynamic tests.
-     *
-     * @return A dynamic test container containing the test for each class which is
-     *         then executed by JUnit.
-     * @throws URISyntaxException an exception if the URI of the class name cannot
-     *                            be generated (which seems to be unlikely)
-     */
-    protected DynamicContainer generateTestsForAllClasses() throws URISyntaxException {
-        List<DynamicNode> tests = new ArrayList<>();
-        if (structureOracleJSON == null) {
-            fail("The ClassTest test can only run if the structural oracle (test.json) is present. If you do not provide it, delete ClassTest.java!");
-        }
-        for (int i = 0; i < structureOracleJSON.length(); i++) {
-            JSONObject expectedClassJSON = structureOracleJSON.getJSONObject(i);
-            JSONObject expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
-            /*
-             * Only test the classes that have additional properties (except name and
-             * package) defined in the structure oracle.
-             */
-            if (expectedClassPropertiesJSON.has(JSON_PROPERTY_NAME)
-                    && expectedClassPropertiesJSON.has(JSON_PROPERTY_PACKAGE)
-                    && hasAdditionalProperties(expectedClassPropertiesJSON)) {
-                String expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
-                String expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
-                ExpectedClassStructure expectedClassStructure = new ExpectedClassStructure(expectedClassName,
-                        expectedPackageName, expectedClassJSON);
-                tests.add(dynamicTest("testClass[" + expectedClassName + "]", () -> testClass(expectedClassStructure)));
-            }
-        }
-        if (tests.isEmpty()) {
-            fail("No tests for classes available in the structural oracle (test.json). Either provide attributes information or delete ClassTest.java!");
-        }
-        /*
-         * Using a custom URI here to workaround surefire rendering the JUnit XML
-         * without the correct test names.
-         */
-        return dynamicContainer(getClass().getName(), new URI(getClass().getName()), tests.stream());
-    }
+	/**
+	 * This method collects the classes in the structure oracle file for which at
+	 * least one class property is specified. These classes are then transformed
+	 * into JUnit 5 dynamic tests.
+	 *
+	 * @return A dynamic test container containing the test for each class which is
+	 *         then executed by JUnit.
+	 * @throws URISyntaxException an exception if the URI of the class name cannot
+	 *                            be generated (which seems to be unlikely)
+	 */
+	protected DynamicContainer generateTestsForAllClasses() throws URISyntaxException {
+		List<DynamicNode> tests = new ArrayList<>();
+		if (structureOracleJSON == null) {
+			fail("The ClassTest test can only run if the structural oracle (test.json) is present. If you do not provide it, delete ClassTest.java!");
+		}
+		for (int i = 0; i < structureOracleJSON.length(); i++) {
+			JSONObject expectedClassJSON = structureOracleJSON.getJSONObject(i);
+			JSONObject expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
+			/*
+			 * Only test the classes that have additional properties (except name and
+			 * package) defined in the structure oracle.
+			 */
+			if (expectedClassPropertiesJSON.has(JSON_PROPERTY_NAME)
+					&& expectedClassPropertiesJSON.has(JSON_PROPERTY_PACKAGE)
+					&& hasAdditionalProperties(expectedClassPropertiesJSON)) {
+				String expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
+				String expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
+				ExpectedClassStructure expectedClassStructure = new ExpectedClassStructure(expectedClassName,
+						expectedPackageName, expectedClassJSON);
+				tests.add(dynamicTest("testClass[" + expectedClassName + "]", () -> testClass(expectedClassStructure)));
+			}
+		}
+		if (tests.isEmpty()) {
+			fail("No tests for classes available in the structural oracle (test.json). Either provide attributes information or delete ClassTest.java!");
+		}
+		/*
+		 * Using a custom URI here to workaround surefire rendering the JUnit XML
+		 * without the correct test names.
+		 */
+		return dynamicContainer(getClass().getName(), new URI(getClass().getName()), tests.stream());
+	}
 
-    protected static boolean hasAdditionalProperties(JSONObject jsonObject) {
-        List<String> keys = new ArrayList<>(jsonObject.keySet());
-        keys.remove(JSON_PROPERTY_NAME);
-        keys.remove(JSON_PROPERTY_PACKAGE);
-        return !keys.isEmpty();
-    }
+	protected static boolean hasAdditionalProperties(JSONObject jsonObject) {
+		List<String> keys = new ArrayList<>(jsonObject.keySet());
+		keys.remove(JSON_PROPERTY_NAME);
+		keys.remove(JSON_PROPERTY_PACKAGE);
+		return !keys.isEmpty();
+	}
 
-    /**
-     * This method gets passed the expected class structure generated by the method
-     * {@link #generateTestsForAllClasses()}, checks if the class is found at all in
-     * the assignment and then proceeds to check its properties.
-     *
-     * @param expectedClassStructure The class structure that we expect to find and
-     *                               test against.
-     */
-    protected void testClass(ExpectedClassStructure expectedClassStructure) {
-        String expectedClassName = expectedClassStructure.getExpectedClassName();
-        Class<?> observedClass = findClassForTestType(expectedClassStructure, "class");
-        if (observedClass == null) {
-            fail(THE_CLASS + expectedClassName + " was not found for class test");
-            return;
-        }
-        JSONObject expectedClassPropertiesJSON = expectedClassStructure.getPropertyAsJsonObject(JSON_PROPERTY_CLASS);
-        checkBasicClassProperties(expectedClassName, observedClass, expectedClassPropertiesJSON);
-        checkSuperclass(expectedClassName, observedClass, expectedClassPropertiesJSON);
-        checkInterfaces(expectedClassName, observedClass, expectedClassPropertiesJSON);
-        checkAnnotations(expectedClassName, observedClass, expectedClassPropertiesJSON);
-    }
+	/**
+	 * This method gets passed the expected class structure generated by the method
+	 * {@link #generateTestsForAllClasses()}, checks if the class is found at all in
+	 * the assignment and then proceeds to check its properties.
+	 *
+	 * @param expectedClassStructure The class structure that we expect to find and
+	 *                               test against.
+	 */
+	protected void testClass(ExpectedClassStructure expectedClassStructure) {
+		String expectedClassName = expectedClassStructure.getExpectedClassName();
+		Class<?> observedClass = findClassForTestType(expectedClassStructure, "class");
+		if (observedClass == null) {
+			fail(THE_CLASS + expectedClassName + " was not found for class test");
+			return;
+		}
+		JSONObject expectedClassPropertiesJSON = expectedClassStructure.getPropertyAsJsonObject(JSON_PROPERTY_CLASS);
+		checkBasicClassProperties(expectedClassName, observedClass, expectedClassPropertiesJSON);
+		checkSuperclass(expectedClassName, observedClass, expectedClassPropertiesJSON);
+		checkInterfaces(expectedClassName, observedClass, expectedClassPropertiesJSON);
+		checkAnnotations(expectedClassName, observedClass, expectedClassPropertiesJSON);
+	}
 
-    private static void checkBasicClassProperties(String expectedClassName, Class<?> observedClass,
-                                                  JSONObject expectedClassPropertiesJSON) {
-        if (checkBooleanOf(expectedClassPropertiesJSON, "isAbstract")
-                && !Modifier.isAbstract(observedClass.getModifiers())) {
-            fail(THE_CLASS + "'" + expectedClassName + "' is not abstract as it is expected.");
-        }
-        if (checkBooleanOf(expectedClassPropertiesJSON, "isEnum") && !observedClass.isEnum()) {
-            fail(THE_TYPE + "'" + expectedClassName + "' is not an enum as it is expected.");
-        }
-        if (checkBooleanOf(expectedClassPropertiesJSON, "isInterface")
-                && !Modifier.isInterface(observedClass.getModifiers())) {
-            fail(THE_TYPE + "'" + expectedClassName + "' is not an interface as it is expected.");
-        }
-    }
+	private static void checkBasicClassProperties(String expectedClassName, Class<?> observedClass,
+			JSONObject expectedClassPropertiesJSON) {
+		if (checkBooleanOf(expectedClassPropertiesJSON, "isAbstract")
+				&& !Modifier.isAbstract(observedClass.getModifiers())) {
+			fail(THE_CLASS + "'" + expectedClassName + "' is not abstract as it is expected.");
+		}
+		if (checkBooleanOf(expectedClassPropertiesJSON, "isEnum") && !observedClass.isEnum()) {
+			fail(THE_TYPE + "'" + expectedClassName + "' is not an enum as it is expected.");
+		}
+		if (checkBooleanOf(expectedClassPropertiesJSON, "isInterface")
+				&& !Modifier.isInterface(observedClass.getModifiers())) {
+			fail(THE_TYPE + "'" + expectedClassName + "' is not an interface as it is expected.");
+		}
+	}
 
-    private static boolean checkBooleanOf(JSONObject expectedClassPropertiesJSON, String booleanProperty) {
-        return expectedClassPropertiesJSON.has(booleanProperty)
-                && expectedClassPropertiesJSON.getBoolean(booleanProperty);
-    }
+	private static boolean checkBooleanOf(JSONObject expectedClassPropertiesJSON, String booleanProperty) {
+		return expectedClassPropertiesJSON.has(booleanProperty)
+				&& expectedClassPropertiesJSON.getBoolean(booleanProperty);
+	}
 
-    private static void checkSuperclass(String expectedClassName, Class<?> observedClass,
-                                        JSONObject expectedClassPropertiesJSON) {
-        // Filter out the enums, since there is a separate test for them
-        if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
-                && !expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS).equals("Enum")) {
-            String actualSuperClassName;
-            String expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
-            if (expectedSuperClassName.contains(".")) {
-                actualSuperClassName = observedClass.getSuperclass().getCanonicalName();
-            } else {
-                actualSuperClassName = observedClass.getSuperclass().getSimpleName();
-            }
-            String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
-                    + expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
-            if (!expectedSuperClassName.equals(actualSuperClassName)) {
-                fail(failMessage);
-            }
-        }
-    }
+	private static void checkSuperclass(String expectedClassName, Class<?> observedClass,
+			JSONObject expectedClassPropertiesJSON) {
+		// Filter out the enums, since there is a separate test for them
+		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
+				&& !expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS).equals("Enum")) {
+			String actualSuperClassName;
+			String expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
+			if (expectedSuperClassName.contains(".")) {
+				actualSuperClassName = observedClass.getSuperclass().getCanonicalName();
+			} else {
+				actualSuperClassName = observedClass.getSuperclass().getSimpleName();
+			}
+			String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
+					+ expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
+			if (!expectedSuperClassName.equals(actualSuperClassName)) {
+				fail(failMessage);
+			}
+		}
+	}
 
-    private static void checkInterfaces(String expectedClassName, Class<?> observedClass,
-                                        JSONObject expectedClassPropertiesJSON) {
-        if (expectedClassPropertiesJSON.has(JSON_PROPERTY_INTERFACES)) {
-            JSONArray expectedInterfaces = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_INTERFACES);
-            Class<?>[] observedInterfaces = observedClass.getInterfaces();
-            for (int i = 0; i < expectedInterfaces.length(); i++) {
-                String expectedInterface = expectedInterfaces.getString(i);
-                boolean hasSpecificPackage = expectedInterface.contains(".");
-                boolean implementsInterface = false;
-                for (Class<?> observedInterface : observedInterfaces) {
-                    if ((hasSpecificPackage && expectedInterface.equals(observedInterface.getCanonicalName())) ||
-                            expectedInterface.equals(observedInterface.getSimpleName())) {
-                        implementsInterface = true;
-                        break;
-                    }
-                }
-                if (!implementsInterface) {
-                    fail(THE_CLASS + "'" + expectedClassName + "' does not implement the interface '"
-                            + expectedInterface + "' as expected." + " Implement the interface and its methods.");
-                }
-            }
-        }
-    }
+	private static void checkInterfaces(String expectedClassName, Class<?> observedClass,
+			JSONObject expectedClassPropertiesJSON) {
+		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_INTERFACES)) {
+			JSONArray expectedInterfaces = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_INTERFACES);
+			Class<?>[] observedInterfaces = observedClass.getInterfaces();
+			for (int i = 0; i < expectedInterfaces.length(); i++) {
+				String expectedInterface = expectedInterfaces.getString(i);
+				boolean hasSpecificPackage = expectedInterface.contains(".");
+				boolean implementsInterface = false;
+				for (Class<?> observedInterface : observedInterfaces) {
+					if ((hasSpecificPackage && expectedInterface.equals(observedInterface.getCanonicalName()))
+							|| expectedInterface.equals(observedInterface.getSimpleName())) {
+						implementsInterface = true;
+						break;
+					}
+				}
+				if (!implementsInterface) {
+					fail(THE_CLASS + "'" + expectedClassName + "' does not implement the interface '"
+							+ expectedInterface + "' as expected." + " Implement the interface and its methods.");
+				}
+			}
+		}
+	}
 
-    private static void checkAnnotations(String expectedClassName, Class<?> observedClass,
-                                         JSONObject expectedClassPropertiesJSON) {
-        if (expectedClassPropertiesJSON.has(JSON_PROPERTY_ANNOTATIONS)) {
-            JSONArray expectedAnnotations = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_ANNOTATIONS);
-            Annotation[] observedAnnotations = observedClass.getAnnotations();
-            boolean annotationsAreRight = checkAnnotations(observedAnnotations, expectedAnnotations);
-            if (!annotationsAreRight) {
-                fail("The annotation(s) of the class '" + expectedClassName + "' are not implemented as expected.");
-            }
-        }
-    }
+	private static void checkAnnotations(String expectedClassName, Class<?> observedClass,
+			JSONObject expectedClassPropertiesJSON) {
+		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_ANNOTATIONS)) {
+			JSONArray expectedAnnotations = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_ANNOTATIONS);
+			Annotation[] observedAnnotations = observedClass.getAnnotations();
+			boolean annotationsAreRight = checkAnnotations(observedAnnotations, expectedAnnotations);
+			if (!annotationsAreRight) {
+				fail("The annotation(s) of the class '" + expectedClassName + "' are not implemented as expected.");
+			}
+		}
+	}
 }

--- a/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
@@ -21,156 +21,156 @@ import org.junit.jupiter.api.DynamicNode;
  * or an interface or an enum and also if the class extends another superclass
  * and if it implements the interfaces and annotations, based on its definition
  * in the structure oracle (test.json).
- * 
+ *
  * @author Stephan Krusche (krusche@in.tum.de)
  * @version 5.0 (11.11.2020)
  */
 public abstract class ClassTestProvider extends StructuralTestProvider {
 
-	/**
-	 * This method collects the classes in the structure oracle file for which at
-	 * least one class property is specified. These classes are then transformed
-	 * into JUnit 5 dynamic tests.
-	 * 
-	 * @return A dynamic test container containing the test for each class which is
-	 *         then executed by JUnit.
-	 * @throws URISyntaxException an exception if the URI of the class name cannot
-	 *                            be generated (which seems to be unlikely)
-	 */
-	protected DynamicContainer generateTestsForAllClasses() throws URISyntaxException {
-		List<DynamicNode> tests = new ArrayList<>();
-		if (structureOracleJSON == null) {
-			fail("The ClassTest test can only run if the structural oracle (test.json) is present. If you do not provide it, delete ClassTest.java!");
-		}
-		for (int i = 0; i < structureOracleJSON.length(); i++) {
-			JSONObject expectedClassJSON = structureOracleJSON.getJSONObject(i);
-			JSONObject expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
-			/*
-			 * Only test the classes that have additional properties (except name and
-			 * package) defined in the structure oracle.
-			 */
-			if (expectedClassPropertiesJSON.has(JSON_PROPERTY_NAME)
-					&& expectedClassPropertiesJSON.has(JSON_PROPERTY_PACKAGE)
-					&& hasAdditionalProperties(expectedClassPropertiesJSON)) {
-				String expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
-				String expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
-				ExpectedClassStructure expectedClassStructure = new ExpectedClassStructure(expectedClassName,
-						expectedPackageName, expectedClassJSON);
-				tests.add(dynamicTest("testClass[" + expectedClassName + "]", () -> testClass(expectedClassStructure)));
-			}
-		}
-		if (tests.isEmpty()) {
-			fail("No tests for classes available in the structural oracle (test.json). Either provide attributes information or delete ClassTest.java!");
-		}
-		/*
-		 * Using a custom URI here to workaround surefire rendering the JUnit XML
-		 * without the correct test names.
-		 */
-		return dynamicContainer(getClass().getName(), new URI(getClass().getName()), tests.stream());
-	}
+    /**
+     * This method collects the classes in the structure oracle file for which at
+     * least one class property is specified. These classes are then transformed
+     * into JUnit 5 dynamic tests.
+     *
+     * @return A dynamic test container containing the test for each class which is
+     *         then executed by JUnit.
+     * @throws URISyntaxException an exception if the URI of the class name cannot
+     *                            be generated (which seems to be unlikely)
+     */
+    protected DynamicContainer generateTestsForAllClasses() throws URISyntaxException {
+        List<DynamicNode> tests = new ArrayList<>();
+        if (structureOracleJSON == null) {
+            fail("The ClassTest test can only run if the structural oracle (test.json) is present. If you do not provide it, delete ClassTest.java!");
+        }
+        for (int i = 0; i < structureOracleJSON.length(); i++) {
+            JSONObject expectedClassJSON = structureOracleJSON.getJSONObject(i);
+            JSONObject expectedClassPropertiesJSON = expectedClassJSON.getJSONObject(JSON_PROPERTY_CLASS);
+            /*
+             * Only test the classes that have additional properties (except name and
+             * package) defined in the structure oracle.
+             */
+            if (expectedClassPropertiesJSON.has(JSON_PROPERTY_NAME)
+                    && expectedClassPropertiesJSON.has(JSON_PROPERTY_PACKAGE)
+                    && hasAdditionalProperties(expectedClassPropertiesJSON)) {
+                String expectedClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_NAME);
+                String expectedPackageName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_PACKAGE);
+                ExpectedClassStructure expectedClassStructure = new ExpectedClassStructure(expectedClassName,
+                        expectedPackageName, expectedClassJSON);
+                tests.add(dynamicTest("testClass[" + expectedClassName + "]", () -> testClass(expectedClassStructure)));
+            }
+        }
+        if (tests.isEmpty()) {
+            fail("No tests for classes available in the structural oracle (test.json). Either provide attributes information or delete ClassTest.java!");
+        }
+        /*
+         * Using a custom URI here to workaround surefire rendering the JUnit XML
+         * without the correct test names.
+         */
+        return dynamicContainer(getClass().getName(), new URI(getClass().getName()), tests.stream());
+    }
 
-	protected static boolean hasAdditionalProperties(JSONObject jsonObject) {
-		List<String> keys = new ArrayList<>(jsonObject.keySet());
-		keys.remove(JSON_PROPERTY_NAME);
-		keys.remove(JSON_PROPERTY_PACKAGE);
-		return !keys.isEmpty();
-	}
+    protected static boolean hasAdditionalProperties(JSONObject jsonObject) {
+        List<String> keys = new ArrayList<>(jsonObject.keySet());
+        keys.remove(JSON_PROPERTY_NAME);
+        keys.remove(JSON_PROPERTY_PACKAGE);
+        return !keys.isEmpty();
+    }
 
-	/**
-	 * This method gets passed the expected class structure generated by the method
-	 * {@link #generateTestsForAllClasses()}, checks if the class is found at all in
-	 * the assignment and then proceeds to check its properties.
-	 * 
-	 * @param expectedClassStructure The class structure that we expect to find and
-	 *                               test against.
-	 */
-	protected void testClass(ExpectedClassStructure expectedClassStructure) {
-		String expectedClassName = expectedClassStructure.getExpectedClassName();
-		Class<?> observedClass = findClassForTestType(expectedClassStructure, "class");
-		if (observedClass == null) {
-			fail(THE_CLASS + expectedClassName + " was not found for class test");
-			return;
-		}
-		JSONObject expectedClassPropertiesJSON = expectedClassStructure.getPropertyAsJsonObject(JSON_PROPERTY_CLASS);
-		checkBasicClassProperties(expectedClassName, observedClass, expectedClassPropertiesJSON);
-		checkSuperclass(expectedClassName, observedClass, expectedClassPropertiesJSON);
-		checkInterfaces(expectedClassName, observedClass, expectedClassPropertiesJSON);
-		checkAnnotations(expectedClassName, observedClass, expectedClassPropertiesJSON);
-	}
+    /**
+     * This method gets passed the expected class structure generated by the method
+     * {@link #generateTestsForAllClasses()}, checks if the class is found at all in
+     * the assignment and then proceeds to check its properties.
+     *
+     * @param expectedClassStructure The class structure that we expect to find and
+     *                               test against.
+     */
+    protected void testClass(ExpectedClassStructure expectedClassStructure) {
+        String expectedClassName = expectedClassStructure.getExpectedClassName();
+        Class<?> observedClass = findClassForTestType(expectedClassStructure, "class");
+        if (observedClass == null) {
+            fail(THE_CLASS + expectedClassName + " was not found for class test");
+            return;
+        }
+        JSONObject expectedClassPropertiesJSON = expectedClassStructure.getPropertyAsJsonObject(JSON_PROPERTY_CLASS);
+        checkBasicClassProperties(expectedClassName, observedClass, expectedClassPropertiesJSON);
+        checkSuperclass(expectedClassName, observedClass, expectedClassPropertiesJSON);
+        checkInterfaces(expectedClassName, observedClass, expectedClassPropertiesJSON);
+        checkAnnotations(expectedClassName, observedClass, expectedClassPropertiesJSON);
+    }
 
-	private static void checkBasicClassProperties(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
-		if (checkBooleanOf(expectedClassPropertiesJSON, "isAbstract")
-				&& !Modifier.isAbstract(observedClass.getModifiers())) {
-			fail(THE_CLASS + "'" + expectedClassName + "' is not abstract as it is expected.");
-		}
-		if (checkBooleanOf(expectedClassPropertiesJSON, "isEnum") && !observedClass.isEnum()) {
-			fail(THE_TYPE + "'" + expectedClassName + "' is not an enum as it is expected.");
-		}
-		if (checkBooleanOf(expectedClassPropertiesJSON, "isInterface")
-				&& !Modifier.isInterface(observedClass.getModifiers())) {
-			fail(THE_TYPE + "'" + expectedClassName + "' is not an interface as it is expected.");
-		}
-	}
+    private static void checkBasicClassProperties(String expectedClassName, Class<?> observedClass,
+                                                  JSONObject expectedClassPropertiesJSON) {
+        if (checkBooleanOf(expectedClassPropertiesJSON, "isAbstract")
+                && !Modifier.isAbstract(observedClass.getModifiers())) {
+            fail(THE_CLASS + "'" + expectedClassName + "' is not abstract as it is expected.");
+        }
+        if (checkBooleanOf(expectedClassPropertiesJSON, "isEnum") && !observedClass.isEnum()) {
+            fail(THE_TYPE + "'" + expectedClassName + "' is not an enum as it is expected.");
+        }
+        if (checkBooleanOf(expectedClassPropertiesJSON, "isInterface")
+                && !Modifier.isInterface(observedClass.getModifiers())) {
+            fail(THE_TYPE + "'" + expectedClassName + "' is not an interface as it is expected.");
+        }
+    }
 
-	private static boolean checkBooleanOf(JSONObject expectedClassPropertiesJSON, String booleanProperty) {
-		return expectedClassPropertiesJSON.has(booleanProperty)
-				&& expectedClassPropertiesJSON.getBoolean(booleanProperty);
-	}
+    private static boolean checkBooleanOf(JSONObject expectedClassPropertiesJSON, String booleanProperty) {
+        return expectedClassPropertiesJSON.has(booleanProperty)
+                && expectedClassPropertiesJSON.getBoolean(booleanProperty);
+    }
 
-	private static void checkSuperclass(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
-		// Filter out the enums, since there is a separate test for them
-		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
-				&& !expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS).equals("Enum")) {
-			String actualSuperClassName;
-			String expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
-			if (expectedSuperClassName.contains(".")) {
-				actualSuperClassName = observedClass.getSuperclass().getCanonicalName();
-			} else {
-				actualSuperClassName = observedClass.getSuperclass().getSimpleName();
-			}
-			String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
-					+ expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
-			if (!expectedSuperClassName.equals(actualSuperClassName)) {
-				fail(failMessage);
-			}
-		}
-	}
+    private static void checkSuperclass(String expectedClassName, Class<?> observedClass,
+                                        JSONObject expectedClassPropertiesJSON) {
+        // Filter out the enums, since there is a separate test for them
+        if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
+                && !expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS).equals("Enum")) {
+            String actualSuperClassName;
+            String expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
+            if (expectedSuperClassName.contains(".")) {
+                actualSuperClassName = observedClass.getSuperclass().getCanonicalName();
+            } else {
+                actualSuperClassName = observedClass.getSuperclass().getSimpleName();
+            }
+            String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
+                    + expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
+            if (!expectedSuperClassName.equals(actualSuperClassName)) {
+                fail(failMessage);
+            }
+        }
+    }
 
-	private static void checkInterfaces(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
-		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_INTERFACES)) {
-			JSONArray expectedInterfaces = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_INTERFACES);
-			Class<?>[] observedInterfaces = observedClass.getInterfaces();
-			for (int i = 0; i < expectedInterfaces.length(); i++) {
-				String expectedInterface = expectedInterfaces.getString(i);
-				boolean hasSpecificPackage = expectedInterface.contains(".");
-				boolean implementsInterface = false;
-				for (Class<?> observedInterface : observedInterfaces) {
-					if ((hasSpecificPackage && expectedInterface.equals(observedInterface.getCanonicalName())) ||
-							expectedInterface.equals(observedInterface.getSimpleName())) {
-						implementsInterface = true;
-						break;
-					}
-				}
-				if (!implementsInterface) {
-					fail(THE_CLASS + "'" + expectedClassName + "' does not implement the interface '"
-							+ expectedInterface + "' as expected." + " Implement the interface and its methods.");
-				}
-			}
-		}
-	}
+    private static void checkInterfaces(String expectedClassName, Class<?> observedClass,
+                                        JSONObject expectedClassPropertiesJSON) {
+        if (expectedClassPropertiesJSON.has(JSON_PROPERTY_INTERFACES)) {
+            JSONArray expectedInterfaces = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_INTERFACES);
+            Class<?>[] observedInterfaces = observedClass.getInterfaces();
+            for (int i = 0; i < expectedInterfaces.length(); i++) {
+                String expectedInterface = expectedInterfaces.getString(i);
+                boolean hasSpecificPackage = expectedInterface.contains(".");
+                boolean implementsInterface = false;
+                for (Class<?> observedInterface : observedInterfaces) {
+                    if ((hasSpecificPackage && expectedInterface.equals(observedInterface.getCanonicalName())) ||
+                            expectedInterface.equals(observedInterface.getSimpleName())) {
+                        implementsInterface = true;
+                        break;
+                    }
+                }
+                if (!implementsInterface) {
+                    fail(THE_CLASS + "'" + expectedClassName + "' does not implement the interface '"
+                            + expectedInterface + "' as expected." + " Implement the interface and its methods.");
+                }
+            }
+        }
+    }
 
-	private static void checkAnnotations(String expectedClassName, Class<?> observedClass,
-			JSONObject expectedClassPropertiesJSON) {
-		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_ANNOTATIONS)) {
-			JSONArray expectedAnnotations = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_ANNOTATIONS);
-			Annotation[] observedAnnotations = observedClass.getAnnotations();
-			boolean annotationsAreRight = checkAnnotations(observedAnnotations, expectedAnnotations);
-			if (!annotationsAreRight) {
-				fail("The annotation(s) of the class '" + expectedClassName + "' are not implemented as expected.");
-			}
-		}
-	}
+    private static void checkAnnotations(String expectedClassName, Class<?> observedClass,
+                                         JSONObject expectedClassPropertiesJSON) {
+        if (expectedClassPropertiesJSON.has(JSON_PROPERTY_ANNOTATIONS)) {
+            JSONArray expectedAnnotations = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_ANNOTATIONS);
+            Annotation[] observedAnnotations = observedClass.getAnnotations();
+            boolean annotationsAreRight = checkAnnotations(observedAnnotations, expectedAnnotations);
+            if (!annotationsAreRight) {
+                fail("The annotation(s) of the class '" + expectedClassName + "' are not implemented as expected.");
+            }
+        }
+    }
 }

--- a/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -124,9 +125,9 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
 				&& !expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS).equals("Enum")) {
 			String expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
-			String observedSuperClassName = observedClass.getSuperclass().getCanonicalName();
 
-			if (!checkExpectedName(observedSuperClassName, expectedSuperClassName)) {
+			if (!checkExpectedType(observedClass.getSuperclass(), observedClass.getGenericSuperclass(),
+					expectedSuperClassName)) {
 				String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
 						+ expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
 				fail(failMessage);
@@ -139,11 +140,14 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_INTERFACES)) {
 			JSONArray expectedInterfaces = expectedClassPropertiesJSON.getJSONArray(JSON_PROPERTY_INTERFACES);
 			Class<?>[] observedInterfaces = observedClass.getInterfaces();
+			Type[] observedGenericInterfaceTypes = observedClass.getGenericInterfaces();
 			for (int i = 0; i < expectedInterfaces.length(); i++) {
 				String expectedInterface = expectedInterfaces.getString(i);
 				boolean implementsInterface = false;
-				for (Class<?> observedInterface : observedInterfaces) {
-					if (checkExpectedName(observedInterface.getCanonicalName(), expectedInterface)) {
+				for (int j = 0; j < observedInterfaces.length; j++) {
+					Class<?> observedInterface = observedInterfaces[j];
+					Type observedGenericInterfaceType = observedGenericInterfaceTypes[j];
+					if (checkExpectedType(observedInterface, observedGenericInterfaceType, expectedInterface)) {
 						implementsInterface = true;
 						break;
 					}

--- a/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
@@ -123,8 +123,13 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 		// Filter out the enums, since there is a separate test for them
 		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_SUPERCLASS)
 				&& !expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS).equals("Enum")) {
+			String actualSuperClassName;
 			String expectedSuperClassName = expectedClassPropertiesJSON.getString(JSON_PROPERTY_SUPERCLASS);
-			String actualSuperClassName = observedClass.getSuperclass().getSimpleName();
+			if (expectedSuperClassName.contains(".")) {
+				actualSuperClassName = observedClass.getSuperclass().getCanonicalName();
+			} else {
+				actualSuperClassName = observedClass.getSuperclass().getSimpleName();
+			}
 			String failMessage = THE_CLASS + "'" + expectedClassName + "' is not a subclass of the class '"
 					+ expectedSuperClassName + "' as expected. Implement the class inheritance properly.";
 			if (!expectedSuperClassName.equals(actualSuperClassName)) {
@@ -140,14 +145,11 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 			Class<?>[] observedInterfaces = observedClass.getInterfaces();
 			for (int i = 0; i < expectedInterfaces.length(); i++) {
 				String expectedInterface = expectedInterfaces.getString(i);
+				boolean hasSpecificPackage = expectedInterface.contains(".");
 				boolean implementsInterface = false;
 				for (Class<?> observedInterface : observedInterfaces) {
-					/*
-					 * TODO: this does not work with the current implementation of the test oracle
-					 * generator (which does not print the simple but the full qualified name
-					 * including the package)
-					 */
-					if (expectedInterface.equals(observedInterface.getSimpleName())) {
+					if ((hasSpecificPackage && expectedInterface.equals(observedInterface.getCanonicalName())) ||
+							expectedInterface.equals(observedInterface.getSimpleName())) {
 						implementsInterface = true;
 						break;
 					}

--- a/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
@@ -120,12 +120,13 @@ public abstract class MethodTestProvider extends StructuralTestProvider {
 				// TODO: check if overloading is supported properly
 
 				if (expectedName.equals(observedMethod.getName())) {
+					String observedReturnTypeName = observedMethod.getReturnType().getCanonicalName();
 					checks.name = true;
 					checks.parameters = checkParameters(observedMethod.getParameterTypes(), expectedParameters);
 					checks.modifiers = checkModifiers(Modifier.toString(observedMethod.getModifiers()).split(" "),
 							expectedModifiers);
 					checks.annotations = checkAnnotations(observedMethod.getAnnotations(), expectedAnnotations);
-					checks.returnType = expectedReturnType.equals(observedMethod.getReturnType().getSimpleName());
+					checks.returnType = checkExpectedName(observedReturnTypeName, expectedReturnType);
 
 					// If all are correct, then we found the desired method and we can break the
 					// loop

--- a/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/MethodTestProvider.java
@@ -120,13 +120,13 @@ public abstract class MethodTestProvider extends StructuralTestProvider {
 				// TODO: check if overloading is supported properly
 
 				if (expectedName.equals(observedMethod.getName())) {
-					String observedReturnTypeName = observedMethod.getReturnType().getCanonicalName();
 					checks.name = true;
 					checks.parameters = checkParameters(observedMethod.getParameterTypes(), expectedParameters);
 					checks.modifiers = checkModifiers(Modifier.toString(observedMethod.getModifiers()).split(" "),
 							expectedModifiers);
 					checks.annotations = checkAnnotations(observedMethod.getAnnotations(), expectedAnnotations);
-					checks.returnType = checkExpectedName(observedReturnTypeName, expectedReturnType);
+					checks.returnType = checkExpectedType(observedMethod.getReturnType(),
+							observedMethod.getGenericReturnType(), expectedReturnType);
 
 					// If all are correct, then we found the desired method and we can break the
 					// loop

--- a/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
@@ -186,7 +186,8 @@ public abstract class StructuralTestProvider {
 			boolean expectedAnnotationFound = false;
 			String expectedAnnotationAsString = (String) expectedAnnotation;
 			for (Annotation observedAnnotation : observedAnnotations) {
-				if (expectedAnnotationAsString.equals(observedAnnotation.annotationType().getSimpleName())) {
+				String observedAnnotationAsString = observedAnnotation.annotationType().getCanonicalName();
+				if (checkExpectedName(observedAnnotationAsString, expectedAnnotationAsString)) {
 					expectedAnnotationFound = true;
 					break;
 				}
@@ -235,11 +236,43 @@ public abstract class StructuralTestProvider {
 
 		String[] observedParameterTypeNames = new String[observedParameters.length];
 		for (int i = 0; i < observedParameters.length; i++) {
+			// TODO: Canonical names should be supported as well.
 			observedParameterTypeNames[i] = observedParameters[i].getSimpleName();
 		}
 		Map<String, Integer> observedParametersHashtable = createParametersHashMap(observedParameterTypeNames);
 
 		return expectedParametersHashtable.equals(observedParametersHashtable);
+	}
+
+	/**
+	 * This method checks whether the actual canonical name of any implemented
+	 * structural element matches its expected name. The expected name can be
+	 * provided as a simple or canonical name.
+	 *
+	 * @param expectedName        The expected simple or canonical name of any
+	 *                            structural element
+	 * @param actualCanonicalName The expected canonical name of any structural
+	 *                            element
+	 * @return True if the names match, false if not.
+	 */
+	protected static boolean checkExpectedName(String actualCanonicalName, String expectedName) {
+		/*
+		 * If the given expected name contains a '.' it can be assumed that it
+		 * represents a full canonical name. If it does not, we can assume it represents
+		 * a simple name.
+		 */
+		if (expectedName.contains(".")) {
+			return expectedName.equals(actualCanonicalName);
+		}
+		/*
+		 * The simple name of an element is always the same as the last element of its
+		 * canonical name, therefore this last element is used for comparison with the
+		 * expected name.
+		 */
+		String[] actualCanonicalNameElements = actualCanonicalName.split("\\.");
+		String actualSimpleName = actualCanonicalNameElements[actualCanonicalNameElements.length - 1];
+
+		return expectedName.equals(actualSimpleName);
 	}
 
 	/**

--- a/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
@@ -6,11 +6,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -80,6 +82,8 @@ public abstract class StructuralTestProvider {
 	protected static final String THE_ENUM = "The enum ";
 
 	protected static final String NOT_IMPLEMENTED_AS_EXPECTED = " are not implemented as expected.";
+
+	private static final Pattern PACKAGE_NAME_IN_GENERIC_TYPE = Pattern.compile("(?:[^\\[\\]<>?,\\s.]++\\.)++");
 
 	protected static JSONArray structureOracleJSON;
 
@@ -186,8 +190,8 @@ public abstract class StructuralTestProvider {
 			boolean expectedAnnotationFound = false;
 			String expectedAnnotationAsString = (String) expectedAnnotation;
 			for (Annotation observedAnnotation : observedAnnotations) {
-				String observedAnnotationAsString = observedAnnotation.annotationType().getCanonicalName();
-				if (checkExpectedName(observedAnnotationAsString, expectedAnnotationAsString)) {
+				if (checkExpectedType(observedAnnotation.annotationType(), observedAnnotation.annotationType(),
+						expectedAnnotationAsString)) {
 					expectedAnnotationFound = true;
 					break;
 				}
@@ -225,8 +229,8 @@ public abstract class StructuralTestProvider {
 		}
 		/*
 		 * Create hash tables to store how often a parameter type occurs. Checking the
-		 * occurrences of a certain parameter type is enough, since the parameter names
-		 * or their order are not relevant to us.
+		 * occurrences of a certain parameter type is enough, since the parameter order
+		 * is not relevant to us.
 		 */
 		String[] expectedParameterTypeNames = new String[expectedParameters.length()];
 		for (int i = 0; i < expectedParameters.length(); i++) {
@@ -245,34 +249,39 @@ public abstract class StructuralTestProvider {
 	}
 
 	/**
-	 * This method checks whether the actual canonical name of any implemented
-	 * structural element matches its expected name. The expected name can be
-	 * provided as a simple or canonical name.
+	 * This method checks whether the actual type of any implemented structural
+	 * element matches its expected name.
 	 *
-	 * @param expectedName        The expected simple or canonical name of any
-	 *                            structural element
-	 * @param actualCanonicalName The expected canonical name of any structural
-	 *                            element
+	 * @param actualClass       The class of the structural element
+	 * @param actualGenericType The actual generic type of the structural element
+	 * @param expectedTypeName  The expected name, provided as a simple or canonical
+	 *                          (generic) name.
 	 * @return True if the names match, false if not.
 	 */
-	protected static boolean checkExpectedName(String actualCanonicalName, String expectedName) {
+	protected static boolean checkExpectedType(Class<?> actualClass, Type actualGenericType, String expectedTypeName) {
+		boolean expectedTypeIsGeneric = expectedTypeName.contains("<") && expectedTypeName.contains(">");
+		String actualName;
+		if (expectedTypeIsGeneric) {
+			actualName = actualGenericType.getTypeName();
+		} else {
+			actualName = actualClass.getCanonicalName();
+			if (actualName == null) {
+				actualName = actualClass.getName();
+			}
+		}
+		String actualSimpleName = PACKAGE_NAME_IN_GENERIC_TYPE.matcher(actualName).replaceAll("");
+
 		/*
 		 * If the given expected name contains a '.' it can be assumed that it
 		 * represents a full canonical name. If it does not, we can assume it represents
 		 * a simple name.
 		 */
-		if (expectedName.contains(".")) {
-			return expectedName.equals(actualCanonicalName);
+		if (expectedTypeName.contains(".")) {
+			return expectedTypeName.equals(actualName);
 		}
-		/*
-		 * The simple name of an element is always the same as the last element of its
-		 * canonical name, therefore this last element is used for comparison with the
-		 * expected name.
-		 */
-		String[] actualCanonicalNameElements = actualCanonicalName.split("\\.");
-		String actualSimpleName = actualCanonicalNameElements[actualCanonicalNameElements.length - 1];
 
-		return expectedName.equals(actualSimpleName);
+		return expectedTypeName.equals(actualSimpleName);
+
 	}
 
 	/**

--- a/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
@@ -270,7 +270,6 @@ public abstract class StructuralTestProvider {
 			}
 		}
 		String actualSimpleName = PACKAGE_NAME_IN_GENERIC_TYPE.matcher(actualName).replaceAll("");
-
 		/*
 		 * If the given expected name contains a '.' it can be assumed that it
 		 * represents a full canonical name. If it does not, we can assume it represents
@@ -279,9 +278,7 @@ public abstract class StructuralTestProvider {
 		if (expectedTypeName.contains(".")) {
 			return expectedTypeName.equals(actualName);
 		}
-
 		return expectedTypeName.equals(actualSimpleName);
-
 	}
 
 	/**


### PR DESCRIPTION
At the moment, ClassTest only allows simple class names for implemented interfaces and superclasses in the structure oracle test file. This is problematic because it is not validated that the actually correct interface or superclass is implemented.
If one exercise contains two interfaces with the same name but in different packages respectively, the ClassTest cannot determine which one of these is the correct one.
Therefore AJTS should be able to handle simple as well as canonical class names in the structure test oracle file correctly. 
Simple names can still be used if the location of an interface or a superclass is up to the student and canonical names will be used if the location of the interface or superclass is already given.