### PR TITLE
Implement optional tags for modifiers in test.json

### DIFF
--- a/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
@@ -112,6 +112,14 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 				&& !Modifier.isInterface(observedClass.getModifiers())) {
 			fail(THE_TYPE + "'" + expectedClassName + "' is not an interface as it is expected.");
 		}
+		if(expectedClassPropertiesJSON.has(JSON_PROPERTY_MODIFIERS)) {
+			JSONArray expectedModifiers = getExpectedJsonProperty(expectedClassPropertiesJSON, JSON_PROPERTY_MODIFIERS);
+			boolean modifiersAreCorrect = checkModifiers(Modifier.toString(observedClass.getModifiers()).split(" "),
+					expectedModifiers);
+			if(!modifiersAreCorrect) {
+				fail("The modifier(s) (access type, abstract, etc.) of " + expectedClassName + NOT_IMPLEMENTED_AS_EXPECTED);
+			}
+		}
 	}
 
 	private static boolean checkBooleanOf(JSONObject expectedClassPropertiesJSON, String booleanProperty) {

--- a/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/ClassTestProvider.java
@@ -112,12 +112,13 @@ public abstract class ClassTestProvider extends StructuralTestProvider {
 				&& !Modifier.isInterface(observedClass.getModifiers())) {
 			fail(THE_TYPE + "'" + expectedClassName + "' is not an interface as it is expected.");
 		}
-		if(expectedClassPropertiesJSON.has(JSON_PROPERTY_MODIFIERS)) {
+		if (expectedClassPropertiesJSON.has(JSON_PROPERTY_MODIFIERS)) {
 			JSONArray expectedModifiers = getExpectedJsonProperty(expectedClassPropertiesJSON, JSON_PROPERTY_MODIFIERS);
 			boolean modifiersAreCorrect = checkModifiers(Modifier.toString(observedClass.getModifiers()).split(" "),
 					expectedModifiers);
-			if(!modifiersAreCorrect) {
-				fail("The modifier(s) (access type, abstract, etc.) of " + expectedClassName + NOT_IMPLEMENTED_AS_EXPECTED);
+			if (!modifiersAreCorrect) {
+				fail("The modifier(s) (access type, abstract, etc.) of " + expectedClassName
+						+ NOT_IMPLEMENTED_AS_EXPECTED);
 			}
 		}
 	}

--- a/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
+++ b/src/main/java/de/tum/in/test/api/structural/StructuralTestProvider.java
@@ -8,7 +8,12 @@ import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URL;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -36,7 +41,7 @@ import de.tum.in.test.api.structural.testutils.ScanResultType;
  * their access modifiers, annotations and types and the declared enum values of
  * an enum</li>
  * </ol>
- * 
+ *
  * All these elements are tests based on the test.json that specifies the
  * structural oracle, i.e. how the solution has to look like in terms of
  * structural elements. Note: the file test.json can be automatically generated
@@ -52,7 +57,7 @@ import de.tum.in.test.api.structural.testutils.ScanResultType;
  * JUnit) If no attributes and no enums should be tested for correctness, remove
  * {@link AttributeTestProvider}, otherwise one test will fail (limitation of
  * JUnit)
- * 
+ *
  * @author Stephan Krusche (krusche@in.tum.de)
  * @version 5.0 (11.11.2020)
  */
@@ -110,7 +115,8 @@ public abstract class StructuralTestProvider {
 			fail(classNameScanMessage);
 		}
 		try {
-			return Class.forName(expectedClassStructure.getQualifiedClassName(), false, StructuralTestProvider.class.getClassLoader());
+			return Class.forName(expectedClassStructure.getQualifiedClassName(), false,
+					StructuralTestProvider.class.getClassLoader());
 		} catch (@SuppressWarnings("unused") ClassNotFoundException e) {
 			// Note: this error happens when the ClassNameScanner finds the correct file,
 			// e.g. 'Course.java', but the class 'Course' was not yet created correctly in
@@ -123,7 +129,7 @@ public abstract class StructuralTestProvider {
 
 	/**
 	 * get the expected elements or an empty JSON array
-	 * 
+	 *
 	 * @param element         the class, attribute, method or constructor JSON
 	 *                        object element
 	 * @param jsonPropertyKey the key used in JSON
@@ -152,28 +158,31 @@ public abstract class StructuralTestProvider {
 		}
 
 		/*
-		 * Otherwise check if all expected necessary modifiers are contained in the array of the
-		 * observed ones and if any forbidden modifiers were used.
+		 * Otherwise check if all expected necessary modifiers are contained in the
+		 * array of the observed ones and if any forbidden modifiers were used.
 		 */
 		Set<ModifierSpecification> modifierSpecifications = new HashSet<>();
-		for(int i = 0; i < expectedModifiers.length(); i++) {
-			modifierSpecifications.add(ModifierSpecification.getModifierForJSONString(expectedModifiers.getString(i)));
+		for (int i = 0; i < expectedModifiers.length(); i++) {
+			modifierSpecifications.add(ModifierSpecification.getModifierForJsonString(expectedModifiers.getString(i)));
 		}
 		Set<String> observedModifiersSet = Set.of(observedModifiers);
-		Set<String> allowedModifiers = modifierSpecifications.stream().map(ModifierSpecification::getModifier).collect(Collectors.toSet());
+		Set<String> allowedModifiers = modifierSpecifications.stream().map(ModifierSpecification::getModifier)
+				.collect(Collectors.toSet());
 		boolean hasAllNecessaryModifiers = modifierSpecifications.stream().filter(ModifierSpecification::isRequired)
 				.map(ModifierSpecification::getModifier).allMatch(observedModifiersSet::contains);
-		boolean hasForbiddenModifier = observedModifiersSet.stream().anyMatch(modifier -> !allowedModifiers.contains(modifier));
+		boolean hasForbiddenModifier = observedModifiersSet.stream()
+				.anyMatch(modifier -> !allowedModifiers.contains(modifier));
 
 		return hasAllNecessaryModifiers && !hasForbiddenModifier;
 	}
 
 	private static final class ModifierSpecification {
+
 		private final String modifier;
 		private final boolean optional;
 
 		private ModifierSpecification(String modifier, boolean optional) {
-			this.modifier = modifier;
+			this.modifier = Objects.requireNonNull(modifier);
 			this.optional = optional;
 		}
 
@@ -185,11 +194,11 @@ public abstract class StructuralTestProvider {
 			return !optional;
 		}
 
-		static ModifierSpecification getModifierForJSONString(String jsonString) {
+		static ModifierSpecification getModifierForJsonString(String jsonString) {
 			String[] sections = jsonString.split(":", -1);
-			if(sections.length == 1) {
+			if (sections.length == 1) {
 				return new ModifierSpecification(jsonString, false);
-			} else if(sections[0].equals("optional")) {
+			} else if (sections[0].equals("optional")) {
 				return new ModifierSpecification(sections[1].trim(), true);
 			} else {
 				throw new IllegalArgumentException("Invalid entry for modifier: '" + jsonString + "'");

--- a/src/test/java/de/tum/in/test/api/StructuralTest.java
+++ b/src/test/java/de/tum/in/test/api/StructuralTest.java
@@ -21,6 +21,7 @@ class StructuralTest {
 	private final String testAttributesSomeClass = "testAttributes()/dynamic-test:#2";
 	private final String testAttributesSomeEnum = "testAttributes()/dynamic-test:#3";
 	private final String testAttributesSomeAbstractClass = "testAttributes()/dynamic-test:#4";
+	private final String testAttributesSomeFailingClass = "testAttributes()/dynamic-test:#5";
 	private final String testClassDoesNotExist = "testClasses()/dynamic-test:#1";
 	private final String testClassSomeInterface = "testClasses()/dynamic-test:#2";
 	private final String testClassMisspelledClas = "testClasses()/dynamic-test:#3";
@@ -35,6 +36,8 @@ class StructuralTest {
 	private final String testMethodsSomeClass = "testMethods()/dynamic-test:#2";
 	private final String testMethodsSomeEnum = "testMethods()/dynamic-test:#3";
 	private final String testMethodsSomeAbstractClass = "testMethods()/dynamic-test:#4";
+
+
 
 	@TestTest
 	void test_testAttributesSomeInterface() {
@@ -61,6 +64,14 @@ class StructuralTest {
 						"The modifier(s) (access type, abstract, etc.) of the expected attribute 'someInt' "
 								+ "of the class 'SomeAbstractClass' are not implemented as expected."));
 	}
+
+	@TestTest
+	void test_testAttributesSomeFailingClass() {
+		tests.assertThatEvents().haveExactly(1,
+				testFailedWith(testAttributesSomeFailingClass, IllegalArgumentException.class,
+						"Invalid entry for modifier: 'penguin: final'"));
+	}
+
 
 	@TestTest
 	void test_testClassDoesNotExist() {

--- a/src/test/java/de/tum/in/test/api/StructuralTest.java
+++ b/src/test/java/de/tum/in/test/api/StructuralTest.java
@@ -29,6 +29,7 @@ class StructuralTest {
 	private final String testClassSomeEnum = "testClasses()/dynamic-test:#5";
 	private final String testClassSomeAbstractClass = "testClasses()/dynamic-test:#6";
 	private final String testClassMisspelledclass = "testClasses()/dynamic-test:#7";
+	private final String testClassSomeFailingClass = "testClasses()/dynamic-test:#8";
 	private final String testConstructorsSomeClass = "testConstructors()/dynamic-test:#1";
 	private final String testConstructorsSomeEnum = "testConstructors()/dynamic-test:#2";
 	private final String testConstructorsSomeAbstractClass = "testConstructors()/dynamic-test:#3";
@@ -112,6 +113,12 @@ class StructuralTest {
 				"The exercise expects a class with the name Misspelledclass. "
 						+ "We found that you implemented a class MisspelledClass, which deviates from the expectation. "
 						+ "Check for wrong upper case / lower case lettering."));
+	}
+
+	@TestTest
+	void test_testClassSomeFailingClass() {
+		tests.assertThatEvents().haveExactly(1, testFailedWith(testClassSomeFailingClass, AssertionFailedError.class,
+				"The modifier(s) (access type, abstract, etc.) of SomeFailingClass are not implemented as expected."));
 	}
 
 	@TestTest

--- a/src/test/java/de/tum/in/test/api/StructuralTest.java
+++ b/src/test/java/de/tum/in/test/api/StructuralTest.java
@@ -37,8 +37,6 @@ class StructuralTest {
 	private final String testMethodsSomeEnum = "testMethods()/dynamic-test:#3";
 	private final String testMethodsSomeAbstractClass = "testMethods()/dynamic-test:#4";
 
-
-
 	@TestTest
 	void test_testAttributesSomeInterface() {
 		tests.assertThatEvents().haveExactly(1, testFailedWith(testAttributesSomeInterface, AssertionFailedError.class,
@@ -67,11 +65,9 @@ class StructuralTest {
 
 	@TestTest
 	void test_testAttributesSomeFailingClass() {
-		tests.assertThatEvents().haveExactly(1,
-				testFailedWith(testAttributesSomeFailingClass, IllegalArgumentException.class,
-						"Invalid entry for modifier: 'penguin: final'"));
+		tests.assertThatEvents().haveExactly(1, testFailedWith(testAttributesSomeFailingClass,
+				IllegalArgumentException.class, "Invalid entry for modifier: 'penguin: final'"));
 	}
-
 
 	@TestTest
 	void test_testClassDoesNotExist() {

--- a/src/test/java/de/tum/in/testuser/subject/structural/SomeClass.java
+++ b/src/test/java/de/tum/in/testuser/subject/structural/SomeClass.java
@@ -11,6 +11,7 @@ public class SomeClass implements SomeInterface {
 	private String someAttribute;
 	private Integer anotherAttribute;
 	private List<Function<? super String, Integer>> doSomethingOperations;
+	private final int someFinalAttribute = SOME_CONSTANT;
 
 	public SomeClass() {
 	}

--- a/src/test/resources/de/tum/in/testuser/test.json
+++ b/src/test/resources/de/tum/in/testuser/test.json
@@ -73,12 +73,16 @@
     "type" : "int"
   }, {
     "name" : "someAttribute",
-    "modifiers" : [ "private" ],
+    "modifiers" : [ "private" , "optional: final"],
     "type" : "String"
   }, {
     "name" : "doSomethingOperations",
     "modifiers" : [ "private" ],
     "type" : "List<Function<? super String, Integer>>"
+  }, {
+    "name" : "someFinalAttribute",
+    "modifiers" : [ "private" , "optional: final"],
+    "type" : "int"
   } ]
 }, {
   "class" : {
@@ -100,7 +104,8 @@
   "class" : {
     "name" : "SomeAbstractClass",
     "package" : "de.tum.in.testuser.subject.structural",
-    "isAbstract" : true
+    "isAbstract" : true,
+    "modifiers" : ["public", "abstract"]
   },
   "methods" : [ {
     "name" : "doNothing",
@@ -122,4 +127,15 @@
     "package" : "de.tum.in.testuser.subject.structural",
     "isInterface" : true
   }
+}, {
+  "class" : {
+    "name" : "SomeFailingClass",
+    "package" : "de.tum.in.testuser.subject.structural",
+    "modifiers" : [ "public", "final" ]
+  },
+  "attributes" : [ {
+    "name" : "SOME_CONSTANT",
+    "modifiers" : [ "penguin: final" ],
+    "type" : "int"
+  } ]
 } ]


### PR DESCRIPTION
This PR enables the option to use `optional:` in front of a modifier in the JSON file of the structural test cases to indicate that this modifier may be included.
The test then accepts all implementations that have every non-optional modifier and doesn't have any modifier that is neither needed nor optional.

Example (An attribute called `someAttribute` that *has to be* `private` and *may be* `final`):
```
{
    "name" : "someAttribute",
    "modifiers" : [ "private" , "optional: final"],
    "type" : "String"
}
  ```

This PR also adds the possibility to test class modifiers:
```
"class" : {
    "name" : "SomeAbstractClass",
    "package" : "de.tum.in.testuser.subject.structural",
    "isAbstract" : true,
    "modifiers" : ["public", "abstract"]
},
```
This could be used to replace `"isAbstract" : true`, however, `isAbstract` will provide a more specific failure message.

***This PR preserves the behavior with all previous formats.***